### PR TITLE
change username input to SteamID

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,18 +100,25 @@ Before you can run this application, you'll need to have the following installed
 1. **Add a Game**:
 
    - Open the application.
-   - Enter the game name and your Steam username.
+   - Enter the game name and your Steam ID (17-digit number).
    - Browse and select the game directory.
    - Browse and select the executable file for the game.
    - (Optional) The application will try to extract the game icon. If it fails, you can manually set an icon path.
    - Click "Add Game".
 
-2. **Manual App ID**:
+2. **Finding Your Steam ID**:
+   - Log in to your Steam account in a web browser.
+   - Go to your profile page.
+   - Your Steam ID is the 17-digit number in the URL of your profile page.
+   - Example: If your profile URL is `https://steamcommunity.com/profiles/78901234567890123`, your Steam ID is `78901234567890123`.
+
+3. **Manual App ID**:
    - If the application can't find the app ID for your game, it will open a browser window with SteamDB.
    - Find the app ID on SteamDB and enter it in the application when prompted.
 
 ## Troubleshooting
 
+- **Invalid Steam ID**: Make sure you're entering a valid 17-digit Steam ID. The application will show an error if the format is incorrect.
 - **Steam is Running**: If Steam is running, the application will prompt you to close it. Make sure to close Steam manually if the application fails to do so.
 - **Configuration Issues**: If the application fails to load or save configurations, check the `config.json` file in the project directory for errors.
 

--- a/game_manager.py
+++ b/game_manager.py
@@ -22,8 +22,8 @@ Methods
 find_ini_file(directory)
     Find the first .ini file in the given directory.
 
-update_ini_file(file_path, steam_id, username)
-    Update the .ini file with the given Steam ID and username.
+update_ini_file(file_path, steam_id)
+    Update the .ini file with the given Steam ID.
 
 create_steam_appid_file(directory, app_id)
     Create a steam_appid.txt file with the given app ID in the specified directory.
@@ -46,8 +46,8 @@ if ini_file:
 else:
     print("No .ini file found.")
 
-# Update .ini file with Steam ID and username
-GameManager.update_ini_file(ini_file, "123456789", "username")
+# Update .ini file with Steam ID
+GameManager.update_ini_file(ini_file, "123456789")
 
 # Create steam_appid.txt file
 GameManager.create_steam_appid_file("path/to/directory", 123456)
@@ -82,14 +82,13 @@ class GameManager:
         return None
 
     @staticmethod
-    def update_ini_file(file_path, steam_id, username):
+    def update_ini_file(file_path, steam_id):
         """
-        Update the .ini file with the given Steam ID and username.
+        Update the .ini file with the given Steam ID.
 
         Args:
             file_path (str): The path to the .ini file to update.
             steam_id (str): The Steam ID to insert into the .ini file.
-            username (str): The username to insert into the .ini file.
         """
         try:
             with open(file_path, 'r') as file:
@@ -99,13 +98,9 @@ class GameManager:
                 for line in lines:
                     if 'PlayerID=' in line or 'AccountId=' in line:
                         file.write(f"AccountId={steam_id}\n")
-                    elif 'UserName=' in line:
-                        file.write(f"UserName={username}\n")
                     else:
                         file.write(line)
-            logging.info(
-                f"Updated .ini file at {file_path} with Steam ID and username."
-            )
+            logging.info(f"Updated .ini file at {file_path} with Steam ID.")
         except Exception as e:
             logging.error(f"Error updating .ini file at {file_path}: {e}")
 

--- a/steam_api.py
+++ b/steam_api.py
@@ -25,9 +25,6 @@ Methods
 __init__(api_key)
     Initialize the SteamAPI class with the provided API key.
 
-get_steam_id(username)
-    Retrieve the Steam ID for a given username.
-
 get_app_list()
     Retrieve the list of all Steam applications.
 
@@ -67,7 +64,7 @@ import logging
 
 class SteamAPI:
     """
-    A class to interact with the Steam Web API for retrieving Steam IDs and app lists.
+    A class to interact with the Steam Web API for retrieving app lists and working with Steam IDs.
     """
 
     BASE_URL = "http://api.steampowered.com"
@@ -83,34 +80,23 @@ class SteamAPI:
         self.api_key = api_key
         self.app_list_cache = None
 
-    def get_steam_id(self, username):
+    def validate_steam_id(self, steam_id):
         """
-        Retrieve the Steam ID for a given username.
+        Validate the format of a given Steam ID.
 
         Args:
-            username (str): The Steam username to retrieve the Steam ID for.
+            steam_id (str): The Steam ID to validate.
 
         Returns:
-            str: The Steam ID if found, else None.
+            bool: True if the Steam ID is valid, False otherwise.
         """
-        try:
-            url = f"{self.BASE_URL}/ISteamUser/ResolveVanityURL/v0001/?key={self.api_key}&vanityurl={username}"
-            response = requests.get(url)
-            response.raise_for_status()
-            data = response.json()
-            steam_id = data['response'].get('steamid')
-            if steam_id:
-                logging.info(
-                    f"Retrieved Steam ID for username '{username}': {steam_id}"
-                )
-                return steam_id
-            logging.warning(
-                f"Steam ID not found for username '{username}'. Response: {data}"
-            )
-            return None
-        except requests.RequestException as e:
-            logging.error(f"Error retrieving Steam ID for username '{username}': {e}")
-            return None
+        # Basic validation: Steam ID should be a 17-digit number
+        if steam_id.isdigit() and len(steam_id) == 17:
+            logging.info(f"Valid Steam ID format: {steam_id}")
+            return True
+        else:
+            logging.warning(f"Invalid Steam ID format: {steam_id}")
+            return False
 
     def get_app_list(self):
         """

--- a/ui.py
+++ b/ui.py
@@ -54,17 +54,17 @@ class NonSteamGameAdderApp:
             row=1, column=1, padx=10, pady=5, sticky=W, columnspan=2
         )
 
-        ttk.Label(frame, text="Steam Username:").grid(
+        ttk.Label(frame, text="Steam ID:").grid(
             row=2, column=0, padx=10, pady=5, sticky=W
         )
-        self.username_entry = ttk.Entry(frame, width=30)
-        self.username_entry.grid(
+        self.steam_id_entry = ttk.Entry(frame, width=30)
+        self.steam_id_entry.grid(
             row=2, column=1, padx=10, pady=5, sticky=W, columnspan=2
         )
 
         config = load_config()
-        if 'username' in config:
-            self.username_entry.insert(0, config['username'])
+        if 'steam_id' in config:
+            self.steam_id_entry.insert(0, config['steam_id'])
 
         self.create_directory_entry(frame)
         self.create_executable_entry(frame)
@@ -146,20 +146,19 @@ class NonSteamGameAdderApp:
 
     def add_game(self):
         game_name = self.game_name_entry.get()
-        username = self.username_entry.get()
+        steam_id = self.steam_id_entry.get()
         game_directory = self.directory_entry.get()
         exe_path = self.exe_entry.get()
         icon_path = self.icon_entry.get()
 
         config = load_config()
-        config['username'] = username
+        config['steam_id'] = steam_id
         save_config(config)
 
         try:
-            steam_id = self.steam_api.get_steam_id(username)
-            if not steam_id:
+            if not self.steam_api.validate_steam_id(steam_id):
                 messagebox.showerror(
-                    "Error", "Steam Username not found. Please enter a valid username."
+                    "Error", "Invalid Steam ID format. Please enter a valid 17-digit Steam ID."
                 )
                 return
 
@@ -175,7 +174,6 @@ class NonSteamGameAdderApp:
                 app_id,
                 game_name,
                 steam_id,
-                username,
                 game_directory,
                 exe_path,
                 icon_path,
@@ -195,8 +193,7 @@ class NonSteamGameAdderApp:
             self.continue_adding_game(
                 app_id,
                 self.game_name_entry.get(),
-                self.steam_api.get_steam_id(self.username_entry.get()),
-                self.username_entry.get(),
+                self.steam_id_entry.get(),
                 self.directory_entry.get(),
                 self.exe_entry.get(),
                 self.icon_entry.get(),
@@ -215,7 +212,7 @@ class NonSteamGameAdderApp:
         submit_button.pack(pady=10)
 
     def continue_adding_game(
-        self, app_id, game_name, steam_id, username, game_directory, exe_path, icon_path
+        self, app_id, game_name, steam_id, game_directory, exe_path, icon_path
     ):
         try:
             if SteamManager.is_steam_running():
@@ -229,7 +226,7 @@ class NonSteamGameAdderApp:
             ini_file = GameManager.find_ini_file(game_directory)
 
             if ini_file:
-                GameManager.update_ini_file(ini_file, steam_id, username)
+                GameManager.update_ini_file(ini_file, steam_id)
                 GameManager.create_steam_appid_file(game_directory, app_id)
                 SteamIntegration.add_non_steam_game(
                     game_name, exe_path, game_directory, icon_path


### PR DESCRIPTION
Looks like Steam API changed and we can use SteamID instead of username. Sometimes it can be frustrating to find steam username alongside with steam display name etc. SteamID is more clear.